### PR TITLE
Updates from Qualcomm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,34 @@
 Rancher Admission Mutating Webhook
 ====
 
-Purpose of this webhook is to associate Aqua segmentation policy based off Rancher projectId labels assigned to namespace.<br/>
-Webhook will intercept k8s deployments and retrieve Rancher ProjectId from namespace field.cattle.io/projectId= and assign<br/>
-to pod template.<br/><br/>
-STATUS: experimental
+Purpose of this webhook is to associate Aqua segmentation policy based off
+Rancher projectId labels assigned to namespace.
+
+The Webhook will intercept k8s deployments and retrieve Rancher ProjectId from
+namespace field.cattle.io/projectId= and assign to pod template.
+
+STATUS: development
 
 ## Configuration
-In the file deploy/setup.sh<br/><br/>
-LABEL_KEY_LOOKING_FOR_ON_NAMESPACE=field.cattle.io/projectId<br/>
-LABEL_KEY_TO_ADD_TO_DEPLOYMENTS=field.cattle.io/projectId<br/>
-IMAGE_NAME=imagename/addlabel:latest  #webhook image name.<br/><br/>
+In the file `deploy/setup.sh`
 
-assumes --enable-admission-plugins=MutatingAdmissionWebhook enabled on k8s api server.<br/>
-https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers <br/><br/>
+    LABEL_KEY_LOOKING_FOR_ON_NAMESPACE=field.cattle.io/projectId
+    LABEL_KEY_TO_ADD_TO_DEPLOYMENTS=field.cattle.io/projectId
+    IMAGE_NAME=imagename/addlabel:latest  #webhook image name.
+
+assumes `--enable-admission-plugins=MutatingAdmissionWebhook` enabled on k8s api server.
+
+https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers 
 
 ## Installation
-1. ./deploy/setup.sh 
+
+Execute `./deploy/setup.sh`
 
 ## Tests
-To run tests: python -m unittest test/test_request.py <br/>
-Assumes >= Python 3.7.4<br/><br/>
+
+To run tests: `python -m unittest test/test_request.py`
+
+Assumes >= Python 3.7.4
 
 ## Overview
 ![alt tag](webhook_overview.png?raw=true "overview")<!-- .element height="50%" width="50%" -->

--- a/README.md
+++ b/README.md
@@ -4,19 +4,18 @@ Rancher Admission Mutating Webhook
 Purpose of this webhook is to associate Aqua segmentation policy based off
 Rancher projectId labels assigned to namespace.
 
-The Webhook will intercept k8s deployments and retrieve Rancher ProjectId from
-namespace field.cattle.io/projectId= and assign to pod template.
+The Webhook will intercept CREATE and UPDATE operations on k8s pods and
+retrieve Rancher ProjectId from the parent namepace's
+`field.cattle.io/projectId=` label, and assign it as a Pod label.
 
 STATUS: development
 
 ## Configuration
-In the file `deploy/setup.sh`
 
-    LABEL_KEY_LOOKING_FOR_ON_NAMESPACE=field.cattle.io/projectId
-    LABEL_KEY_TO_ADD_TO_DEPLOYMENTS=field.cattle.io/projectId
-    IMAGE_NAME=imagename/addlabel:latest  #webhook image name.
+Look at the top of the file `deploy/setup.sh` for a number of environment
+variables that configure behavior
 
-assumes `--enable-admission-plugins=MutatingAdmissionWebhook` enabled on k8s api server.
+Functionality assumes `--enable-admission-plugins=MutatingAdmissionWebhook` enabled on k8s api server.
 
 https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers 
 
@@ -29,6 +28,33 @@ Execute `./deploy/setup.sh`
 To run tests: `python -m unittest test/test_request.py`
 
 Assumes >= Python 3.7.4
+
+## Troubleshooting
+
+The `add-labels-*` pods will emit terse but useful information to STDOUT, e.g.:
+
+    Processing CREATE operation on Pod/v1 named webapp-778bb599cd-?? in pkrizaktest namespace
+    Found label {'field.cattle.io/projectId': 'p-8v8fr'} on namespace pkrizaktest
+    Applied label drekar.qualcomm.com~1projectId=p-8v8fr to pod
+    172.19.5.0 - - [24/Jan/2020 01:04:53] "POST /addlabel?timeout=30s HTTP/1.1" 200 -
+
+    Processing UPDATE operation on Pod/v1 named webapp-778bb599cd-5gwn6 in pkrizaktest namespace
+    Found label {'field.cattle.io/projectId': 'p-8v8fr'} on namespace pkrizaktest
+    Applied label drekar.qualcomm.com~1projectId=p-8v8fr to pod
+    172.19.5.0 - - [24/Jan/2020 01:05:20] "POST /addlabel?timeout=30s HTTP/1.1" 200 -
+
+For more verbose information, edit the `add-labels` deployment and set
+`WEBHOOK_DEBUG` environment variable to `"1"`.  In addition to the
+terse information shown above, the contents of the admission request
+will be logged.  This is very helpful when troubleshooting a `KeyError`
+in the code or something.
+
+If the admission controller doesn't seem to be executing at all,
+examine the logs of the kube-apiserver.  For example, this is
+an error message indicating that the SSL certificate has the
+wrong CN (it needs to match the K8s service name).
+
+    1 dispatcher.go:137] failed calling webhook "addlabel.aquasec.com": Post https://addlabel-webhook.aqua-addlabel-webhook.svc:443/addlabel?timeox509: certificate is valid for addlabel-webhook.default.svc, not addlabel-webhook.aqua-addlabel-webhook.svc
 
 ## Overview
 ![alt tag](webhook_overview.png?raw=true "overview")<!-- .element height="50%" width="50%" -->

--- a/app/add_label.py
+++ b/app/add_label.py
@@ -20,10 +20,10 @@ def get_namespace_labels(namespace):
     return labels
 
 
-@admission_controller.route('/add/labels/deployments', methods=['POST'])
+@admission_controller.route('/addlabel', methods=['POST'])
 def add_labels_deployment():
     request_info = request.get_json()
-    utils.logging('DEPLOYMENT OBJECT', request_info)
+    utils.logging('POD OBJECT', request_info)
 
     namespace = utils.get_namespace(request_info)
 
@@ -37,9 +37,8 @@ def add_labels_deployment():
             utils.logging('LABELS FOUND', f"{labels} on namespace {namespace}")
             utils.logging('LABELS APPLIED', f"{label_key}={projectId} on pod template." )
 
-            return admission_response_patch(True, "Adding Rancher ProjectId Label to Deployment",
-                                        json_patch=jsonpatch.JsonPatch([{"op": "add", "path": f"/spec/template/metadata/labels/{label_key}",
-                                                                        "value": projectId}]))
+            return admission_response_patch(True, "Adding Rancher ProjectId Label to Pod",
+                                        json_patch=jsonpatch.JsonPatch([{"op": "add", "path": f"/metadata/labels/{label_key}", "value": projectId}]))
 
     utils.logging('LABEL NOT FOUND', f"{LABEL_KEY_LOOKING_FOR_ON_NAMESPACE} not found on namespace {namespace}")
 

--- a/app/add_label.py
+++ b/app/add_label.py
@@ -15,7 +15,7 @@ v1 = client.CoreV1Api()
 def get_namespace_labels(namespace):
     resp = v1.read_namespace(namespace)
     labels = utils.parse_namespace_label(resp, LABEL_KEY_LOOKING_FOR_ON_NAMESPACE)
-    utils.logging('NAMESPACE OBJECT', resp)
+    utils.debug('NAMESPACE OBJECT', resp)
 
     return labels
 
@@ -23,27 +23,37 @@ def get_namespace_labels(namespace):
 @admission_controller.route('/addlabel', methods=['POST'])
 def add_labels_deployment():
     request_info = request.get_json()
-    utils.logging('POD OBJECT', request_info)
+    utils.debug('REQUEST OBJECT', request_info)
+    try:
+        operation = request_info["request"]["operation"]
+        namespace = request_info["request"]["namespace"]
+        kind = request_info["request"]["kind"]["kind"]
+        version = request_info["request"]["kind"]["version"]
+        podname = "(unknown)"
+        if "metadata" in request_info["request"]["object"]:
+            if "name" in request_info["request"]["object"]["metadata"]:
+                podname = request_info["request"]["object"]["metadata"]["name"]
+            elif "generateName" in request_info["request"]["object"]["metadata"]:
+                podname = "{}??".format(request_info["request"]["object"]["metadata"]["generateName"])
+    except KeyError as e:
+        print(e)
+        return jsonify({"response": {"allowed": True, "status": {"message": f"Malformed request: {e}"}}})
 
-    namespace = utils.get_namespace(request_info)
+    print(f"Processing {operation} operation on {kind}/{version} named {podname} in {namespace} namespace")
 
-    if namespace is not None:
-        labels = get_namespace_labels(namespace)
+    labels = get_namespace_labels(namespace)
+    if labels is not None:
+        projectId = labels[LABEL_KEY_LOOKING_FOR_ON_NAMESPACE]
+        label_key = LABEL_KEY_TO_ADD_TO_DEPLOYMENTS.replace('/', '~1')
 
-        if labels is not None:
-            projectId = labels[LABEL_KEY_LOOKING_FOR_ON_NAMESPACE]
-            label_key = LABEL_KEY_TO_ADD_TO_DEPLOYMENTS.replace('/', '~1')
+        print(f"Found label {labels} on namespace {namespace}")
+        print(f"Applied label {label_key}={projectId} to pod" )
 
-            utils.logging('LABELS FOUND', f"{labels} on namespace {namespace}")
-            utils.logging('LABELS APPLIED', f"{label_key}={projectId} on pod template." )
-
-            return admission_response_patch(True, "Adding Rancher ProjectId Label to Pod",
-                                        json_patch=jsonpatch.JsonPatch([{"op": "add", "path": f"/metadata/labels/{label_key}", "value": projectId}]))
-
-    utils.logging('LABEL NOT FOUND', f"{LABEL_KEY_LOOKING_FOR_ON_NAMESPACE} not found on namespace {namespace}")
-
-    return jsonify({"response": {"allowed": True, "status": {"message": "No Rancher ProjectId found"}}})
-
+        return admission_response_patch(True, "Adding Rancher ProjectId Label to Pod",
+                                    json_patch=jsonpatch.JsonPatch([{"op": "add", "path": f"/metadata/labels/{label_key}", "value": projectId}]))
+    else:
+        print(f"ERROR: label {LABEL_KEY_LOOKING_FOR_ON_NAMESPACE} not found on namespace {namespace}")
+        return jsonify({"response": {"allowed": True, "status": {"message": "No Rancher ProjectId found"}}})
 
 def admission_response_patch(allowed, message, json_patch):
     base64_patch = base64.b64encode(json_patch.to_string().encode("utf-8")).decode("utf-8")

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,4 @@
 Flask==1.1.1
 jsonpatch
 kubernetes
+pprint

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,12 +1,5 @@
-
-
-def get_namespace(request):
-    namespace = None
-    if 'request' in request and 'namespace' in request['request']:
-        namespace = request["request"]["namespace"]
-
-    return namespace
-
+import os
+from pprint import pprint
 
 def parse_namespace_label(namespace_object, find_label):
     labels = None
@@ -18,7 +11,8 @@ def parse_namespace_label(namespace_object, find_label):
     return labels
 
 
-def logging(title, message):
-    print(f"*** START {title} *****************************************************")
-    print(message)
-    print(f"*** END {title} *******************************************************")
+def debug(title, message):
+    if os.environ.get("WEBHOOK_DEBUG", "0") == "1":
+        print(f"*** START {title} *****************************************************")
+        pprint(message)
+        print(f"*** END {title} *******************************************************")

--- a/deploy/certs/generate_certs.sh
+++ b/deploy/certs/generate_certs.sh
@@ -1,3 +1,9 @@
+SERVICE_FQDN=$1
+if [ -z "$SERVICE_FQDN" ]; then
+    echo "ERROR: Second parameter must be service FQDN"
+    exit 1
+fi
+
 openssl genrsa -out /certs/ca.key 2048
 openssl req -x509 -new -nodes -key /certs/ca.key -days 100000 -out /certs/ca.crt -subj "/CN=admission_ca"
 cat >/certs/server.conf <<EOF
@@ -11,7 +17,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, serverAuth
 EOF
 openssl genrsa -out /certs/server.key 2048
-openssl req -new -key /certs/server.key -out /certs/server.csr -subj "/CN=addlabel-webhook.default.svc" -config /certs/server.conf
+openssl req -new -key /certs/server.key -out /certs/server.csr -subj "/CN=$SERVICE_FQDN" -config /certs/server.conf
 openssl x509 -req -in /certs/server.csr -CA /certs/ca.crt -CAkey /certs/ca.key -CAcreateserial -out /certs/server.crt -days 100000 -extensions v3_req -extfile /certs/server.conf
 
 # make the keys mode 644 so the build script can read it as a non-root user

--- a/deploy/certs/generate_certs.sh
+++ b/deploy/certs/generate_certs.sh
@@ -1,6 +1,6 @@
 SERVICE_FQDN=$1
 if [ -z "$SERVICE_FQDN" ]; then
-    echo "ERROR: Second parameter must be service FQDN"
+    echo "ERROR: First parameter must be service FQDN"
     exit 1
 fi
 

--- a/deploy/certs/generate_certs.sh
+++ b/deploy/certs/generate_certs.sh
@@ -13,3 +13,6 @@ EOF
 openssl genrsa -out /certs/server.key 2048
 openssl req -new -key /certs/server.key -out /certs/server.csr -subj "/CN=addlabel-webhook.default.svc" -config /certs/server.conf
 openssl x509 -req -in /certs/server.csr -CA /certs/ca.crt -CAkey /certs/ca.key -CAcreateserial -out /certs/server.crt -days 100000 -extensions v3_req -extfile /certs/server.conf
+
+# make the keys mode 644 so the build script can read it as a non-root user
+chmod 644 /certs/server.key /certs/ca.key

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -110,7 +110,6 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: addlabel-admission-hook-config
-  namespace: $NAMESPACE
   labels:
     component: mutating-controller
 webhooks:

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -12,6 +12,7 @@ MAINTAINER='Jeff Thorne'
 EMAIL='jthorne@u.washington.edu'
 LABEL_KEY_LOOKING_FOR_ON_NAMESPACE=field.cattle.io/projectId #the label key on the parent namespace that contains the project ID
 LABEL_KEY_TO_ADD_TO_DEPLOYMENTS=drekar.qualcomm.com/projectId #label key to tattoo into deployments
+SERVICE_NAME=addlabel-webhook
 NAMESPACE=aqua-addlabel-webhook
 BUILD_DIR=/tmp/aqua-addlabel-deploy # should be on local disk, not NFS
 ### end configuraton
@@ -68,7 +69,7 @@ docker push $IMAGE_NAME
 
 echo "Creating certificates in $BUILD_DIR/certs..."
 cp deploy/certs/generate_certs.sh $BUILD_DIR/certs/
-docker run --rm -v $BUILD_DIR/certs:/certs jordi/openssl bash /certs/generate_certs.sh
+docker run --rm -v $BUILD_DIR/certs:/certs jordi/openssl bash /certs/generate_certs.sh $SERVICE_NAME.$NAMESPACE.svc
 
 echo "Creating $BUILD_DIR/deploy/cluster_role.yaml..."
 cat <<EOF >$BUILD_DIR/deploy/cluster_role.yaml
@@ -133,7 +134,7 @@ cat <<EOF >$BUILD_DIR/deploy/deploy_controller.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: addlabel-webhook
+  name: $SERVICE_NAME
   namespace: $NAMESPACE
 spec:
   ports:

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -7,7 +7,7 @@ set -e
 PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
 
 ### configuraton
-IMAGE_NAME="docker-registry.qualcomm.com/drekar/aqua-addlabel:0.1" #this script will build and push an image with this name. Registry access assumed.
+IMAGE_NAME="docker-registry.qualcomm.com/drekar/aqua-addlabel:0.2" #this script will build and push an image with this name. Registry access assumed.
 MAINTAINER='Jeff Thorne'
 EMAIL='jthorne@u.washington.edu'
 LABEL_KEY_LOOKING_FOR_ON_NAMESPACE=field.cattle.io/projectId #the label key on the parent namespace that contains the project ID
@@ -120,11 +120,11 @@ webhooks:
       service:
         name: addlabel-webhook
         namespace: $NAMESPACE
-        path: /add/labels/deployments
+        path: /addlabel
       caBundle: $(cat $BUILD_DIR/certs/ca.crt | base64 | tr -d '\n') # a base64 encoded self signed ca cert is needed because all Admission Webhooks need to be on SSL
     rules:
       - apiGroups: ["*"]
-        resources: ["deployments"]
+        resources: ["pods"]
         apiVersions: ["*"]
         operations: ["CREATE", "UPDATE"]
 EOF


### PR DESCRIPTION
* Apply labels to pods, not deployments
* Rework deployment to use temporary filesystem instead of pwd
* Scale admission deployment to 2 pods
* Rename non-namespaced resources with `aqua-` prefix
* Make default log output terse and more informative
* Add debug flag
* Rearrange Dockerfile to better leverage cached layers
* Add troubleshooting info to README
* Ensure certificates get built with correct CN